### PR TITLE
Bug 1288547: Add Firefox Nightly supported locales to Ship It

### DIFF
--- a/kickoff/config.py
+++ b/kickoff/config.py
@@ -2,6 +2,7 @@
 NIGHTLY_VERSION = "50.0a1"
 AURORA_VERSION = "49.0a2"
 SUPPORTED_AURORA_LOCALES = ['ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg', 'bn-BD', 'bn-IN', 'br', 'brx', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en-GB', 'en-US', 'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja', 'ka', 'kk', 'km', 'kn', 'ko', 'kok', 'ks', 'lij', 'lt', 'lv', 'mai', 'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'nl', 'nn-NO', 'oc', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'sat', 'si', 'sk', 'sl', 'sq', 'son', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tr', 'uk', 'uz', 'vi', 'xh', 'zh-CN', 'zh-TW']
+SUPPORTED_NIGHTLY_LOCALES = ['ar', 'ast', 'cs', 'de', 'en-GB', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'fa', 'fr', 'fy-NL', 'gl', 'he', 'hu', 'id', 'it', 'ja', 'ja-JP-mac', 'kk', 'ko', 'lt', 'lv', 'nb-NO', 'nl', 'nn-NO', 'pl', 'pt-BR', 'pt-PT', 'ru', 'sk', 'sl', 'sv-SE', 'th', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
 LATEST_FIREFOX_OLDER_VERSION = "3.6.28"
 CURRENT_ESR = "45"
 ESR_NEXT = ""

--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -180,12 +180,20 @@ def generateLocalizedBuilds(buildsVersionLocales, l10nchangesets, lastVersion):
     return buildsVersionLocales
 
 
-def fillAuroraVersion(buildsVersionLocales):
-    for localeCode in config.SUPPORTED_AURORA_LOCALES:
+def fillPrereleaseVersion(buildsVersionLocales, channel='aurora'):
+    # Our default values are for Aurora
+    locales = config.SUPPORTED_AURORA_LOCALES
+    version = config.AURORA_VERSION
+
+    if channel == 'nightly':
+        locales = config.SUPPORTED_NIGHTLY_LOCALES
+        version = config.NIGHTLY_VERSION
+
+    for localeCode in locales:
         if localeCode not in buildsVersionLocales.keys():
-            buildsVersionLocales[localeCode] = [config.AURORA_VERSION]
+            buildsVersionLocales[localeCode] = [version]
         else:
-            buildsVersionLocales[localeCode] += [config.AURORA_VERSION]
+            buildsVersionLocales[localeCode] += [version]
 
     return buildsVersionLocales
 
@@ -210,7 +218,9 @@ def updateLocaleWithVersionsTable(product):
     buildsVersionLocales = generateLocalizedBuilds(buildsVersionLocales,
                                                    lastStable[0][2],
                                                    lastStable[0][0])
-    buildsVersionLocales = fillAuroraVersion(buildsVersionLocales)
+    buildsVersionLocales = fillPrereleaseVersion(buildsVersionLocales, 'aurora')
+    buildsVersionLocales = fillPrereleaseVersion(buildsVersionLocales, 'nightly')
+
     return buildsVersionLocales
 
 

--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -182,12 +182,8 @@ def generateLocalizedBuilds(buildsVersionLocales, l10nchangesets, lastVersion):
 
 def fillPrereleaseVersion(buildsVersionLocales, channel='aurora'):
     # Our default values are for Aurora
-    locales = config.SUPPORTED_AURORA_LOCALES
-    version = config.AURORA_VERSION
-
-    if channel == 'nightly':
-        locales = config.SUPPORTED_NIGHTLY_LOCALES
-        version = config.NIGHTLY_VERSION
+    locales = config.SUPPORTED_NIGHTLY_LOCALES if channel == 'nightly' else config.SUPPORTED_AURORA_LOCALES
+    version = config.NIGHTLY_VERSION if channel == 'nightly' else config.AURORA_VERSION
 
     for localeCode in locales:
         if localeCode not in buildsVersionLocales.keys():

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -91,6 +91,14 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertTrue('en-US' in primary)
         # but no just en
         self.assertTrue('en' not in primary)
+        # We will always have Nightly and Aurora builds for French
+        self.assertTrue('fr' in config.SUPPORTED_NIGHTLY_LOCALES)
+        self.assertTrue('fr' in config.SUPPORTED_AURORA_LOCALES)
+        self.assertEquals(len(primary['fr']), 2)
+        # We don't have Nightly builds for Acholi but have Aurora builds
+        self.assertFalse('ach' in config.SUPPORTED_NIGHTLY_LOCALES)
+        self.assertTrue('ach' in config.SUPPORTED_AURORA_LOCALES)
+        self.assertEquals(len(primary['ach']), 1)
 
     def testTBPrimaryBuilds(self):
         ret = self.get('/json/thunderbird_primary_builds.json')


### PR DESCRIPTION
* Add a SUPPORTED_NIGHTLY_LOCALES constant in config.py, data copied from http://hg.mozilla.org/mozilla-central/raw-file/default/browser/locales/all-locales
* Replace the function fillAuroraVersion() by fillPrereleaseVersion() which can be called with an optional parameter to indicate the channel (aurora or nightly)

This patch works for me locally with a dump of the database from June. If you test it with the same dump, you will have to adjust the values in config.py for Firefox releases to correspond with what is in the dump:

 NIGHTLY_VERSION = "50.0a1"
 AURORA_VERSION = "49.0a2"
 CURRENT_ESR = "38" 