### PR TITLE
Bug 1288755: update list of Aurora locales for Desktop

### DIFF
--- a/kickoff/config.py
+++ b/kickoff/config.py
@@ -1,8 +1,8 @@
 # Not used
 NIGHTLY_VERSION = "50.0a1"
 AURORA_VERSION = "49.0a2"
-SUPPORTED_AURORA_LOCALES = ['ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg', 'bn-BD', 'bn-IN', 'br', 'brx', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en-GB', 'en-US', 'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja', 'ka', 'kk', 'km', 'kn', 'ko', 'kok', 'ks', 'lij', 'lt', 'lv', 'mai', 'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'nl', 'nn-NO', 'oc', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'sat', 'si', 'sk', 'sl', 'sq', 'son', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tr', 'uk', 'uz', 'vi', 'xh', 'zh-CN', 'zh-TW']
-SUPPORTED_NIGHTLY_LOCALES = ['ar', 'ast', 'cs', 'de', 'en-GB', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'fa', 'fr', 'fy-NL', 'gl', 'he', 'hu', 'id', 'it', 'ja', 'ja-JP-mac', 'kk', 'ko', 'lt', 'lv', 'nb-NO', 'nl', 'nn-NO', 'pl', 'pt-BR', 'pt-PT', 'ru', 'sk', 'sl', 'sv-SE', 'th', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
+SUPPORTED_AURORA_LOCALES = ['ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg', 'bn-BD', 'bn-IN', 'br', 'brx', 'bs', 'ca', 'cak', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en-GB', 'en-US', 'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gn', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja', 'ja-JP-mac', 'ka', 'kk', 'km', 'kn', 'ko', 'kok', 'ks', 'lij', 'lt', 'ltg', 'lv', 'mai', 'mk', 'ml', 'mr', 'ms', 'nb-NO', 'ne-NP', 'nl', 'nn-NO', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'sat', 'si', 'sk', 'sl', 'sq', 'son', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tr', 'uk', 'ur', 'uz', 'vi', 'xh', 'zh-CN', 'zh-TW']
+SUPPORTED_NIGHTLY_LOCALES = ['ar', 'ast', 'cs', 'de', 'en-GB', 'en-US', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'fa', 'fr', 'fy-NL', 'gl', 'he', 'hu', 'id', 'it', 'ja', 'ja-JP-mac', 'kk', 'ko', 'lt', 'lv', 'nb-NO', 'nl', 'nn-NO', 'pl', 'pt-BR', 'pt-PT', 'ru', 'sk', 'sl', 'sv-SE', 'th', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
 LATEST_FIREFOX_OLDER_VERSION = "3.6.28"
 CURRENT_ESR = "45"
 ESR_NEXT = ""


### PR DESCRIPTION
This patch removes oc and my locales (Occitan and Burmese) to be in sync with what we ship on Aurora. 