### PR TITLE
Bug 1290789: firefox_primary_builds.json should have release and beta  values for en-US

### DIFF
--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -158,6 +158,9 @@ def generateLocalizedBuilds(buildsVersionLocales, l10nchangesets, lastVersion):
     # parse it
     locales = parsePlainL10nChangesets(l10nchangesets)
 
+    # We don't have an l10n changeset for en-US but we need en-US in the output
+    locales['en-US'] = 'abcd123456'
+
     for localeCode in locales:
         version = _generateDummyFileSizeMetaData(lastVersion)
         if localeCode not in buildsVersionLocales.keys():

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -109,6 +109,13 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertFalse('ach' in config.SUPPORTED_NIGHTLY_LOCALES)
         self.assertTrue('ach' in config.SUPPORTED_AURORA_LOCALES)
         self.assertEquals(len(primary['ach']), 1)
+        # We always have en-US for all channels
+        self.assertTrue('23.0a2' in primary['en-US'])
+        self.assertTrue('24.0a1' in primary['en-US'])
+        self.assertTrue('3.0b3' in primary['en-US'])
+        self.assertTrue('2.0' in primary['en-US'])
+        self.assertTrue('2.0.2' in primary['en-US'])
+        self.assertEquals(len(primary['en-US']), 5)
 
     def testTBPrimaryBuilds(self):
         ret = self.get(BASE_JSON_PATH + '/thunderbird_primary_builds.json')


### PR DESCRIPTION

firefox_primary_builds.json does not have beta and release fields for en-US because
those are built with generateLocalizedBuilds() and based on the existence of an
l10n changeset.

The fix is to add an artificial changeset for en-US in generateLocalizedBuilds() because we will always ship en-US.

The tests added for en-US cover all channels. Note that there is a separate bug about the esr suffix missing, that is Bug 1290725.
That means that I am not including the esr suffix in the test, I will fix the test with Bug 1290725, ex:
self.assertTrue('2.0.2' in primary['en-US'])
will become once Bug 1290725 is fixed:
self.assertTrue('2.0.2esr' in primary['en-US'])