### PR TITLE
Bug 1290719 - Add Android supported locale lists to mobile_details.json

### DIFF
--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -221,22 +221,26 @@ def firefox_primary_builds_json():
 
 # Mobile JSON
 
+def mobileVersions():
+    versions = {
+        "nightly_version": config.NIGHTLY_VERSION,
+        "alpha_version": config.AURORA_VERSION,
+        "ios_version": config.IOS_VERSION,
+        "ios_beta_version": config.IOS_BETA_VERSION,
+        "stable": getFilteredReleases("fennec", ["major", "stability"], lastRelease=True)[0][0],
+        "beta_version": getFilteredReleases("fennec", ["dev"], lastRelease=True)[0][0]
+    }
+    return versions
+
+
+@app.route(BASE_JSON_PATH + '/mobile_versions.json', methods=['GET'])
+def mobileVersionsJson():
+    return returnJSONVersionFile('mobile_versions.json', mobileVersions())
+
 
 @app.route(BASE_JSON_PATH + '/mobile_details.json', methods=['GET'])
-@app.route(BASE_JSON_PATH + '/mobile_versions.json', methods=['GET'])
 def mobileDetailsJson():
-    versions = {"nightly_version": config.NIGHTLY_VERSION,
-                "alpha_version": config.AURORA_VERSION,
-                "ios_version": config.IOS_VERSION,
-                "ios_beta_version": config.IOS_BETA_VERSION
-                }
-
-    lastStable = getFilteredReleases("fennec", ["major", "stability"], lastRelease=True)
-    versions['stable'] = lastStable[0][0]
-
-    lastBeta = getFilteredReleases("fennec", ["dev"], lastRelease=True)
-    versions['beta_version'] = lastBeta[0][0]
-    return returnJSONVersionFile('mobile_versions.json', versions)
+    return returnJSONVersionFile('mobile_details.json', mobileVersions())
 
 
 @app.route(BASE_JSON_PATH + '/mobile_history_major_releases.json', methods=['GET'])

--- a/kickoff/templates/json_exports.html
+++ b/kickoff/templates/json_exports.html
@@ -6,13 +6,7 @@ Compared to the PHP based product details, a few changes can be found:
   <li>
   firefox_beta_builds.json no longer exist it was very likely unused
   </li>
-  <li>
-  firefox_primary_builds.json no longer provide the file size. Causing the list of version to be an JSON array instead of a JSON dict
-  </li>
-  <li>
-  mobile_details.json no longer have the locale field as it was badly structured and probably never used
-  </li>
-  <li>mobile_versions.json has been introduced to match firefox_versions.json & thunderbird_versions.json filename. It is just an alias
+  <li>mobile_versions.json has been introduced to match firefox_versions.json & thunderbird_versions.json filename.
   </li>
   <li>thunderbird_versions.json now shows the beta version
   </li>

--- a/kickoff/templates/mobile_details.json
+++ b/kickoff/templates/mobile_details.json
@@ -1,0 +1,361 @@
+{
+  "nightly_version": "{{ versions.nightly_version }}",
+  "alpha_version": "{{ versions.alpha_version }}",
+  "beta_version": "{{ versions.beta_version }}",
+  "version": "{{ versions.stable }}",
+  "ios_beta_version": "{{ versions.ios_beta_version }}",
+  "ios_version": "{{ versions.ios_version }}",
+  "builds": [
+        {
+            "locale": {
+                "code": "ar",
+                "english": "Arabic",
+                "native": "\u0639\u0631\u0628\u064a"
+            }
+        },
+        {
+            "locale": {
+                "code": "be",
+                "english": "Belarusian",
+                "native": "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f"
+            }
+        },
+        {
+            "locale": {
+                "code": "ca",
+                "english": "Catalan",
+                "native": "Catal\u00e0"
+            }
+        },
+        {
+            "locale": {
+                "code": "cs",
+                "english": "Czech",
+                "native": "\u010ce\u0161tina"
+            }
+        },
+        {
+            "locale": {
+                "code": "de",
+                "english": "German",
+                "native": "Deutsch"
+            }
+        },
+        {
+            "locale": {
+                "code": "en-US",
+                "english": "English (US)",
+                "native": "English (US)"
+            }
+        },
+        {
+            "locale": {
+                "code": "es-AR",
+                "english": "Spanish (Argentina)",
+                "native": "Espa\u00f1ol (de Argentina)"
+            }
+        },
+        {
+            "locale": {
+                "code": "es-ES",
+                "english": "Spanish (Spain)",
+                "native": "Espa\u00f1ol (de Espa\u00f1a)"
+            }
+        },
+        {
+            "locale": {
+                "code": "eu",
+                "english": "Basque",
+                "native": "Euskara"
+            }
+        },
+        {
+            "locale": {
+                "code": "fa",
+                "english": "Persian",
+                "native": "\u0641\u0627\u0631\u0633\u06cc"
+            }
+        },
+        {
+            "locale": {
+                "code": "fi",
+                "english": "Finnish",
+                "native": "suomi"
+            }
+        },
+        {
+            "locale": {
+                "code": "fr",
+                "english": "French",
+                "native": "Fran\u00e7ais"
+            }
+        },
+        {
+            "locale": {
+                "code": "fy-NL",
+                "english": "Frisian",
+                "native": "Frysk"
+            }
+        },
+        {
+            "locale": {
+                "code": "ga-IE",
+                "english": "Irish",
+                "native": "Gaeilge"
+            }
+        },
+        {
+            "locale": {
+                "code": "gl",
+                "english": "Galician",
+                "native": "Galego"
+            }
+        },
+        {
+            "locale": {
+                "code": "hu",
+                "english": "Hungarian",
+                "native": "magyar"
+            }
+        },
+        {
+            "locale": {
+                "code": "it",
+                "english": "Italian",
+                "native": "Italiano"
+            }
+        },
+        {
+            "locale": {
+                "code": "ja",
+                "english": "Japanese",
+                "native": "\u65e5\u672c\u8a9e"
+            }
+        },
+        {
+            "locale": {
+                "code": "lt",
+                "english": "Lithuanian",
+                "native": "lietuvi\u0173 kalba"
+            }
+        },
+        {
+            "locale": {
+                "code": "nl",
+                "english": "Dutch",
+                "native": "Nederlands"
+            }
+        },
+        {
+            "locale": {
+                "code": "pa-IN",
+                "english": "Punjabi (India)",
+                "native": "\u0a2a\u0a70\u0a1c\u0a3e\u0a2c\u0a40 (\u0a2d\u0a3e\u0a30\u0a24)"
+            }
+        },
+        {
+            "locale": {
+                "code": "pl",
+                "english": "Polish",
+                "native": "Polski"
+            }
+        },
+        {
+            "locale": {
+                "code": "pt-BR",
+                "english": "Portuguese (Brazilian)",
+                "native": "Portugu\u00eas (do\u00a0Brasil)"
+            }
+        },
+        {
+            "locale": {
+                "code": "pt-PT",
+                "english": "Portuguese (Portugal)",
+                "native": "Portugu\u00eas (Europeu)"
+            }
+        },
+        {
+            "locale": {
+                "code": "ro",
+                "english": "Romanian",
+                "native": "Rom\u00e2n\u0103"
+            }
+        },
+        {
+            "locale": {
+                "code": "ru",
+                "english": "Russian",
+                "native": "\u0420\u0443\u0441\u0441\u043a\u0438\u0439"
+            }
+        },
+        {
+            "locale": {
+                "code": "sk",
+                "english": "Slovak",
+                "native": "sloven\u010dina"
+            }
+        },
+        {
+            "locale": {
+                "code": "tr",
+                "english": "Turkish",
+                "native": "T\u00fcrk\u00e7e"
+            }
+        },
+        {
+            "locale": {
+                "code": "uk",
+                "english": "Ukrainian",
+                "native": "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430"
+            }
+        },
+        {
+            "locale": {
+                "code": "zh-CN",
+                "english": "Chinese (Simplified)",
+                "native": "\u4e2d\u6587 (\u7b80\u4f53)"
+            }
+        },
+        {
+            "locale": {
+                "code": "zh-TW",
+                "english": "Chinese (Traditional)",
+                "native": "\u6b63\u9ad4\u4e2d\u6587 (\u7e41\u9ad4)"
+            }
+        }
+    ],
+    "beta_builds": [
+        {
+            "locale": {
+                "code": "cs",
+                "english": "Czech",
+                "native": "\u010ce\u0161tina"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "de",
+                "english": "German",
+                "native": "Deutsch"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "en-US",
+                "english": "English (US)",
+                "native": "English (US)"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "es-ES",
+                "english": "Spanish (Spain)",
+                "native": "Espa\u00f1ol (de Espa\u00f1a)"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "fi",
+                "english": "Finnish",
+                "native": "suomi"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "fr",
+                "english": "French",
+                "native": "Fran\u00e7ais"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "it",
+                "english": "Italian",
+                "native": "Italiano"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "ja",
+                "english": "Japanese",
+                "native": "\u65e5\u672c\u8a9e"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "nl",
+                "english": "Dutch",
+                "native": "Nederlands"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "pl",
+                "english": "Polish",
+                "native": "Polski"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "pt-PT",
+                "english": "Portuguese (Portugal)",
+                "native": "Portugu\u00eas (Europeu)"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        },
+        {
+            "locale": {
+                "code": "ru",
+                "english": "Russian",
+                "native": "\u0420\u0443\u0441\u0441\u043a\u0438\u0439"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox_beta"
+            }
+        }
+    ],
+    "alpha_builds": [
+        {
+            "locale": {
+                "code": "en-US",
+                "english": "English (US)",
+                "native": "English (US)"
+            },
+            "download": {
+                "android": "market:\/\/details?id=org.mozilla.firefox"
+            }
+        }
+    ]
+}

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -181,6 +181,27 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(versions['ios_version'], "1.1")
         self.assertEquals(versions['ios_beta_version'], "1.2")
 
+    def testMobileDetails(self):
+        config.CURRENT_ESR = "2"
+        config.ESR_NEXT = "38"
+        config.NIGHTLY_VERSION = "24.0a1"
+        config.AURORA_VERSION = "23.0a2"
+        config.IOS_VERSION = "1.1"
+        config.IOS_BETA_VERSION = "1.2"
+        ret = self.get(BASE_JSON_PATH + '/mobile_details.json')
+        details = json.loads(ret.data)
+
+        self.assertEquals(ret.status_code, 200)
+        self.assertEquals(details['nightly_version'], "24.0a1")
+        self.assertEquals(details['alpha_version'], "23.0a2")
+        self.assertEquals(details['beta_version'], "23.0b2")
+        self.assertEquals(details['version'], "24.0")
+        self.assertEquals(details['ios_version'], "1.1")
+        self.assertEquals(details['ios_beta_version'], "1.2")
+        self.assertTrue("builds" in details)
+        self.assertTrue("alpha_builds" in details)
+        self.assertTrue("beta_builds" in details)
+
     def testThunderbirdVersions(self):
         ret = self.get(BASE_JSON_PATH + '/thunderbird_versions.json')
         versions = json.loads(ret.data)


### PR DESCRIPTION
- use a separate template for mobile_details.json and hardcode there the locales data that was missing
- create a mobileVersions() method used by the two views mobileVersionsJson() and mobileDetailsJson()
- update doc and add tests