### PR TITLE
Bug 1292419, match number of partials in suggestion to current limits

### DIFF
--- a/kickoff/static/suggestions.js
+++ b/kickoff/static/suggestions.js
@@ -168,7 +168,7 @@ function populatePartial(name, version, previousBuilds, partialElement) {
         }
 
         partialsADI = isCurrentVersionESR ? allPartial.esr : allPartial.release;
-        nbPartial = 4; // For thunderbird, use only the four last
+        nbPartial = isCurrentVersionESR ? 1 : 3; // 1 for ESR; max of 3 for promotion until we chain tasks instead of group
     }
 
     // Transform the partialsADI datastruct in a single array to

--- a/kickoff/static/suggestions.js
+++ b/kickoff/static/suggestions.js
@@ -74,7 +74,7 @@ function guessBranchFromVersion(name, version) {
 }
 
 function addLastVersionAsPartial(version, previousReleases, nb) {
-    partialList = '';
+    partialList = [];
     nbAdded = 0;
     // We always add the last released version to the list
     for (k = 0; k < previousReleases.length; k++) {
@@ -89,7 +89,7 @@ function addLastVersionAsPartial(version, previousReleases, nb) {
         }
 
         if (previousRelease < version) {
-            partialList += previousReleases[k] + ',';
+            partialList.push(previousReleases[k]);
             nbAdded++;
             if (nb == nbAdded) {
                 return partialList;
@@ -185,7 +185,7 @@ function populatePartial(name, version, previousBuilds, partialElement) {
     // Check that all partials match a build.
     partialConsistencyCheck(partialsADIVersion, previousReleases);
 
-    partial = '';
+    partial = [];
     partialAdded = 0;
 
     // When we have the ADI for Firefox Beta or Thunderbird, we can remove
@@ -194,9 +194,7 @@ function populatePartial(name, version, previousBuilds, partialElement) {
         // No ADI, select the three first
         partial = addLastVersionAsPartial(version, previousReleases, 3);
         partialAdded = 3;
-        // Remove the last ","
-        partial = partial.slice(0,-1);
-        partialElement.val(partial);
+        partialElement.val(partial.join());
         return true;
     } else {
         // The first partial will always be the previous published release
@@ -205,33 +203,20 @@ function populatePartial(name, version, previousBuilds, partialElement) {
     }
 
     for (i = 0; i < partialsADIVersion.length; i++) {
-
-        if (partial.indexOf(partialsADIVersion[i]  + 'build') > -1) {
-            // We have already this version in the list of partial
-            // Go to the next one
-            continue;
-        }
-        // Build a previous release should not occur but it is the case
-        // don't provide past partials
         newPartial = getVersionWithBuildNumber(partialsADIVersion[i], previousReleases);
-        if (newPartial != undefined) {
-            // Only add when we found a matching version
-            partial += newPartial;
+        if (newPartial != undefined &&
+            partial.indexOf(newPartial) < 0) {
+            // Only add when we found a matching version we haven't used already
+            partial.push(newPartial);
             partialAdded++;
         }
 
-        if (i + 1 != partialsADIVersion.length &&
-            partialAdded != nbPartial &&
-            newPartial != undefined) {
-            // We don't want a trailing ","
-            partial += ',';
-        }
         if (partialAdded == nbPartial) {
             // We have enough partials. Bye bye.
             break;
         }
     }
-    partialElement.val(partial);
+    partialElement.val(partial.join());
     return true;
 }
 

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -156,7 +156,7 @@ var result = populatePartial("firefox", "33.2", previousBuilds, partialElement);
 assert.ok( result );
 // 33.0.1 has 0 as ADI but this is ok
 // Take the two next partials with the most ADI
-assert.strictEqual($('#partials').val(), "33.0.1build2,32.0.1build2,31.0build2,30.0.5build7")
+assert.strictEqual($('#partials').val(), "33.0.1build2,32.0.1build2,31.0build2")
 
 // Beta (will use partialFXBeta)
 partialElement = $('#partials');
@@ -173,7 +173,7 @@ assert.strictEqual($('#partials').val(), "");
 partialElement = $('#partials');
 var result = populatePartial("firefox", "31.2.0esr", previousBuilds, partialElement);
 assert.ok( result );
-assert.strictEqual($('#partials').val(), "31.1.0esrbuild1,29.4.0esrbuild1,24.3.0esrbuild1,29.0esrbuild1");
+assert.strictEqual($('#partials').val(), "31.1.0esrbuild1");
 
 // Thunderbird
 previousBuilds = {"releases/comm-esr31": ["31.0build1", "24.1.0build1", "24.3.0build1", "24.4.0build1"]},
@@ -194,7 +194,7 @@ previousBuilds = {"releases/mozilla-release": ["36.0.4build2", "36.0.3build2",  
 partialElement = $('#partials');
 var result = populatePartial("firefox", "37.0", previousBuilds, partialElement);
 assert.ok( result );
-assert.strictEqual($('#partials').val(), "36.0.4build2,36.0.3build2,35.0build2,36.0build2");
+assert.strictEqual($('#partials').val(), "36.0.4build2,36.0.3build2,35.0build2");
 
 // Test the case we had during the 38 cycle (beta built from m-r)
 allPartialJ='{"release": [{"version": "38.0.3", "ADI": 5000}, {"version": "35.0", "ADI": 3000}, {"version": "36.0", "ADI": 500}]}';

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -95,13 +95,13 @@ QUnit.test( "addLastVersionAsPartial", function( assert ) {
                       "releases/mozilla-esr31": ["31.1.0esrbuild1", "29.4.0esrbuild1", "29.2.0esrbuild1", "24.3.0esrbuild1" ]};
 
     previousReleases = previousBuilds[base + 'release'].sort().reverse();
-    assert.strictEqual( addLastVersionAsPartial("35.0", previousReleases, 1), "33.0.1build2,");
+    assert.deepEqual( addLastVersionAsPartial("35.0", previousReleases, 1), ["33.0.1build2"]);
 
     previousReleases = previousBuilds[base + 'beta'].sort().reverse();
-    assert.strictEqual( addLastVersionAsPartial("35.0b2", previousReleases, 1), "31.0b2build2,");
+    assert.deepEqual( addLastVersionAsPartial("35.0b2", previousReleases, 1), ["31.0b2build2"]);
 
     previousReleases = previousBuilds[base + 'esr31'].sort().reverse();
-    assert.strictEqual( addLastVersionAsPartial("38.0esr", previousReleases, 1), "31.1.0esrbuild1,");
+    assert.deepEqual( addLastVersionAsPartial("38.0esr", previousReleases, 1), ["31.1.0esrbuild1"]);
 });
 
 

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -209,11 +209,11 @@ assert.strictEqual($('#partials').val(), "38.0.3build2,35.0build2,36.0build2");
 allPartialJ='{"release": [{"version": "38.0.3", "ADI": 5000}, {"version": "35.0", "ADI": 3000}, {"version": "36.0", "ADI": 500}]}';
 allPartial=JSON.parse(allPartialJ);
 
-previousBuilds = {"releases/mozilla-release": ["38.0.5bbuild2", "38.0.3build2", "38.0b6build2",  "36.0build2", "35.0build2"]}
+previousBuilds = {"releases/mozilla-release": ["38.0.5b3build2", "38.0.3build2", "38.0b6build2",  "36.0build2", "35.0build2"]}
 
 partialElement = $('#partials');
 var result = populatePartial("firefox", "39.0", previousBuilds, partialElement);
 assert.ok( result );
-assert.strictEqual($('#partials').val(), "38.0.5bbuild2,38.0.3build2,35.0build2,36.0build2");
+assert.strictEqual($('#partials').val(), "38.0.3build2,35.0build2,36.0build2");
 
 });

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -140,7 +140,9 @@ QUnit.test( "getVersionWithBuildNumber", function( assert ) {
 
 QUnit.test( "populatePartial", function( assert ) {
 
-allPartialJ='{"release": [{"version": "32.0.1", "ADI": 949}, {"version": "31.0", "ADI": 821}, {"version": "30.0.5", "ADI": 661}, {"version": "29.0", "ADI": 438}, {"version": "28.0", "ADI": 256}], "beta": [{"version": "31.0b2", "ADI": 951}, {"version": "31.0b3", "ADI": 879}, {"version": "30.0b9", "ADI": 776}, {"version": "30.0b2", "ADI": 655}, {"version": "29.0b10", "ADI": 273}], "esr": [{"version": "31.1.0esr", "ADI": 833}, {"version": "29.4.0esr", "ADI": 763}, {"version": "24.3.0esr", "ADI": 624}, {"version": "29.0esr", "ADI": 558}, {"version": "31.3.0esr", "ADI": 368}]}';
+allPartialJ='{"release": [{"version": "32.0.1", "ADI": 949}, {"version": "31.0", "ADI": 821}, {"version": "30.0.5", "ADI": 661}, {"version": "29.0", "ADI": 438}, {"version": "28.0", "ADI": 256}],' +
+            ' "beta": [{"version": "31.0b2", "ADI": 951}, {"version": "31.0b3", "ADI": 879}, {"version": "30.0b9", "ADI": 776}, {"version": "30.0b2", "ADI": 655}, {"version": "29.0b10", "ADI": 273}],' +
+            ' "esr": [{"version": "31.1.0esr", "ADI": 833}, {"version": "29.4.0esr", "ADI": 763}, {"version": "24.3.0esr", "ADI": 624}, {"version": "29.0esr", "ADI": 558}, {"version": "31.3.0esr", "ADI": 368}]}';
 allPartial=JSON.parse(allPartialJ);
 
 previousBuilds = {"releases/mozilla-beta": ["31.0b3build4", "31.0b2build2", "30.0b9build2", "29.0b10build2", "25.0b5build2", "30.0b2build1" ],


### PR DESCRIPTION
We normally use 1 partial for Firefox ESR (but ship-it suggests 4), and are limited to 3 partials for release promotion (by the task graph, we suggesting 4 for release), so this makes ship-it match up to that reality. While I was here I simplified the code a bit by using an array instead of a string, and fixed a broken test.