### PR TITLE
Bug 1289781 - Output of firefox_primary_builds_json() is not ordered by key

### DIFF
--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from kickoff import app
 from kickoff import config
 
-from flask import jsonify, render_template, make_response
+from flask import render_template, make_response
 
 from kickoff.model import getReleases
 
@@ -13,7 +13,7 @@ from kickoff.thunderbirddetails import primary_builds as tb_primary_builds, beta
 
 from mozilla.release.l10n import parsePlainL10nChangesets
 
-from jsonexportcommon import myjsonify
+from jsonexportcommon import myjsonify, jsonify_by_sorting_keys
 from jsonexportl10n import generateRegionsJSONFileList, generateL10NJSONFileList
 
 
@@ -219,7 +219,7 @@ def updateLocaleWithVersionsTable(product):
 @app.route(BASE_JSON_PATH + '/firefox_primary_builds.json', methods=['GET'])
 def firefox_primary_builds_json():
     buildsVersionLocales = updateLocaleWithVersionsTable("firefox")
-    return jsonify(buildsVersionLocales)
+    return jsonify_by_sorting_keys(buildsVersionLocales)
 
 
 # Mobile JSON

--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -13,7 +13,7 @@ from kickoff.thunderbirddetails import primary_builds as tb_primary_builds, beta
 
 from mozilla.release.l10n import parsePlainL10nChangesets
 
-from jsonexportcommon import myjsonify, jsonify_by_sorting_keys
+from jsonexportcommon import jsonify_by_sorting_values, jsonify_by_sorting_keys
 from jsonexportl10n import generateRegionsJSONFileList, generateL10NJSONFileList
 
 
@@ -97,21 +97,21 @@ BASE_JSON_PATH = '/json/' + JSON_VER
 def firefoxHistoryMajorReleasesJson():
     # Match X.Y and 14.0.1 (special case)
     values = getFilteredReleases("firefox", "major")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 @app.route(BASE_JSON_PATH + '/firefox_history_stability_releases.json', methods=['GET'])
 def firefoxHistoryStabilityReleasesJson():
     # Match X.Y.Z (including esr) + W.X.Y.Z (example 1.5.0.8)
     values = getFilteredReleases("firefox", "stability")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 @app.route(BASE_JSON_PATH + '/firefox_history_development_releases.json', methods=['GET'])
 def firefoxHistoryDevelopmentReleasesJson():
     # Match 23.b2, 1.0rc2, 3.6.3plugin1 or 3.6.4build7
     values = getFilteredReleases("firefox", "dev")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 @app.route(BASE_JSON_PATH + '/firefox_versions.json', methods=['GET'])
@@ -249,20 +249,20 @@ def mobileDetailsJson():
 @app.route(BASE_JSON_PATH + '/mobile_history_major_releases.json', methods=['GET'])
 def mobileHistoryMajorReleasesJson():
     values = getFilteredReleases("fennec", "major")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 @app.route(BASE_JSON_PATH + '/mobile_history_stability_releases.json', methods=['GET'])
 def mobileHistoryReleasesJson():
     values = getFilteredReleases("fennec", "stability")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 @app.route(BASE_JSON_PATH + '/mobile_history_development_releases.json', methods=['GET'])
 def mobileHistoryDevelopmentReleasesJson():
     # Match 23.b2, 1.0rc2, 3.6.3plugin1 or 3.6.4build7
     values = getFilteredReleases("fennec", "dev")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 # THUNDERBIRD JSON
@@ -270,20 +270,20 @@ def mobileHistoryDevelopmentReleasesJson():
 @app.route(BASE_JSON_PATH + '/thunderbird_history_major_releases.json', methods=['GET'])
 def thunderbirdHistoryMajorReleasesJson():
     values = getFilteredReleases("thunderbird", "major")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 @app.route(BASE_JSON_PATH + '/thunderbird_history_stability_releases.json', methods=['GET'])
 def thunderbirdHistoryReleasesJson():
     values = getFilteredReleases("thunderbird", "stability")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 @app.route(BASE_JSON_PATH + '/thunderbird_history_development_releases.json', methods=['GET'])
 def thunderbirdHistoryDevelopmentReleasesJson():
     # Match 23.b2, 1.0rc2, 3.6.3plugin1 or 3.6.4build7
     values = getFilteredReleases("thunderbird", "dev")
-    return myjsonify(values)
+    return jsonify_by_sorting_values(values)
 
 
 @app.route(BASE_JSON_PATH + '/thunderbird_versions.json', methods=['GET'])
@@ -293,7 +293,7 @@ def thunderbirdVersionsJson():
         "LATEST_THUNDERBIRD_DEVEL_VERSION": getFilteredReleases("thunderbird", ["dev"], lastRelease=True)[0][0],
         "LATEST_THUNDERBIRD_ALPHA_VERSION": config.LATEST_THUNDERBIRD_ALPHA_VERSION,
     }
-    return myjsonify(versions)
+    return jsonify_by_sorting_values(versions)
 
 
 @app.route(BASE_JSON_PATH + '/thunderbird_primary_builds.json', methods=['GET'])
@@ -304,12 +304,12 @@ def thunderbirdPrimaryBuildsJson():
     tb_prim = {}
     for key in tb_primary_builds:
         tb_prim[key] = common
-    return myjsonify(tb_prim)
+    return jsonify_by_sorting_values(tb_prim)
 
 
 @app.route(BASE_JSON_PATH + '/thunderbird_beta_builds.json', methods=['GET'])
 def thunderbirdBetaBuildsJson():
-    return myjsonify(tb_beta_builds)
+    return jsonify_by_sorting_values(tb_beta_builds)
 
 
 @app.route(BASE_JSON_PATH + '/languages.json', methods=['GET'])
@@ -327,7 +327,7 @@ def jsonExports():
 def jsonExportsJson():
     """ Export the list of files a friendly way to json """
     jsonFiles = generateJSONFileList(withL10Nfiles=True)
-    return myjsonify(jsonFiles)
+    return jsonify_by_sorting_values(jsonFiles)
 
 
 @app.route('/json_exports.txt', methods=['GET'])
@@ -363,21 +363,21 @@ def getReleasesForJson(product):
 def jsonFirefoxExport():
     """ Export all the firefox versions """
     release_list = getReleasesForJson("firefox")
-    return myjsonify(release_list, detailledJson=True)
+    return jsonify_by_sorting_values(release_list, detailledJson=True)
 
 
 @app.route(BASE_JSON_PATH + '/mobile_android.json', methods=['GET'])
 def jsonFennecExport():
     """ Export all the fennec versions """
     release_list = getReleasesForJson("fennec")
-    return myjsonify(release_list, detailledJson=True)
+    return jsonify_by_sorting_values(release_list, detailledJson=True)
 
 
 @app.route(BASE_JSON_PATH + '/thunderbird.json', methods=['GET'])
 def jsonThunderbirdExport():
     """ Export all the thunderbird versions """
     release_list = getReleasesForJson("thunderbird")
-    return myjsonify(release_list, detailledJson=True)
+    return jsonify_by_sorting_values(release_list, detailledJson=True)
 
 
 @app.route(BASE_JSON_PATH + '/all.json', methods=['GET'])
@@ -388,4 +388,4 @@ def jsonAllExport():
     }
     for release in ("firefox", "fennec", "thunderbird"):
         release_list["releases"].update(getReleasesForJson(release)["releases"])
-    return myjsonify(release_list, detailledJson=True)
+    return jsonify_by_sorting_values(release_list, detailledJson=True)

--- a/kickoff/jsonexportcommon.py
+++ b/kickoff/jsonexportcommon.py
@@ -28,7 +28,7 @@ def jsonify_by_sorting_values(values, detailledJson=False):
 
 
 def jsonify_by_sorting_keys(values):
-    return _craft_response(json.dumps(values, sort_keys=True))
+    return _craft_response(json.dumps(values, sort_keys=True, indent=4))
 
 
 def _craft_response(json_value):

--- a/kickoff/jsonexportcommon.py
+++ b/kickoff/jsonexportcommon.py
@@ -25,8 +25,15 @@ def myjsonify(values, detailledJson=False):
     else:
         values = valuesOrdered
 
-    # Don't use jsonsify because jsonify is sorting
-    resp = Response(response=json.dumps(values),
+    return _craft_response(json.dumps(values))
+
+
+def jsonify_by_sorting_keys(values):
+    return _craft_response(json.dumps(values, sort_keys=True))
+
+
+def _craft_response(json_value):
+    resp = Response(response=json_value,
                     status=200,
                     mimetype="application/json")
     return(resp)

--- a/kickoff/jsonexportcommon.py
+++ b/kickoff/jsonexportcommon.py
@@ -7,8 +7,7 @@ except ImportError:
     from ordereddict import OrderedDict
 
 
-def myjsonify(values, detailledJson=False):
-    # Transform the structure into a dict
+def jsonify_by_sorting_values(values, detailledJson=False):
     values = OrderedDict(values)
 
     if detailledJson:

--- a/kickoff/jsonexportcommon.py
+++ b/kickoff/jsonexportcommon.py
@@ -24,6 +24,7 @@ def jsonify_by_sorting_values(values, detailledJson=False):
     else:
         values = valuesOrdered
 
+    # jsonsify from flask is not used on purpose. It sorts the JSON by the hashes of the keys
     return _craft_response(json.dumps(values))
 
 

--- a/kickoff/jsonexportl10n.py
+++ b/kickoff/jsonexportl10n.py
@@ -13,7 +13,7 @@ from mozilla.release.l10n import parsePlainL10nChangesets
 
 from kickoff.model import getReleases
 from kickoff.model import getReleaseTable
-from jsonexportcommon import myjsonify
+from jsonexportcommon import jsonify_by_sorting_values
 
 JSON_VER = config.JSON_FORMAT_L10N_VERSION
 BASE_JSON_PATH_L10N = '/json/' + JSON_VER + '/l10n/'
@@ -30,7 +30,7 @@ def l10nExport(releaseName):
     else:
         l10n_list = _getLocalesByReleaseName(releaseTable, releaseName)
 
-    return myjsonify(l10n_list)
+    return jsonify_by_sorting_values(l10n_list)
 
 
 def _aggregateBetaLocales(releaseTable, releaseName):
@@ -51,7 +51,7 @@ def _getLocalesByReleaseName(releaseTable, releaseName):
 
 def _getReleaseLocales(release):
     if release is None or release.l10nChangesets == config.LEGACY_KEYWORD:
-        return myjsonify({})
+        return jsonify_by_sorting_values({})
 
     locale_list = defaultdict()
     if "Firefox" in release.name or "Thunderbird" in release.name:

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -84,8 +84,8 @@ class TestJSONRequestsAPI(ViewTest):
 
     def testPrimaryBuilds(self):
         ret = self.get(BASE_JSON_PATH + '/firefox_primary_builds.json')
-        primary = json.loads(ret.data)
         self.assertEquals(ret.status_code, 200)
+        primary = json.loads(ret.data)
         # I guess we will always have more than 20 locales
         self.assertTrue(len(primary) > 20)
         # i guess we will always have french or german
@@ -120,6 +120,12 @@ class TestJSONRequestsAPI(ViewTest):
         # ja-JP-mac is not a locale we want to expose into product-details
         self.assertFalse('ja-JP-mac' in primary)
 
+    def testPrimaryBuildsAreSorted(self):
+        ret = self.get(BASE_JSON_PATH + '/firefox_primary_builds.json')
+        self.assertEquals(ret.status_code, 200)
+        givenString = ret.data
+        sortedJsonString = json.dumps(json.loads(givenString), sort_keys=True, indent=4)
+        self.assertEqual(givenString, sortedJsonString)
 
     def testTBPrimaryBuilds(self):
         ret = self.get(BASE_JSON_PATH + '/thunderbird_primary_builds.json')


### PR DESCRIPTION
Unlike what [this comment claims](https://github.com/mozilla-releng/ship-it/pull/99/files#diff-2f7d65b9fa27da274006f9931c00473eL28), `jsonify()` from flask [doesn't sort keys](https://github.com/pallets/flask/blob/0.9/flask/helpers.py#L197). If delegates `dumps()` to either [simplejson](http://simplejson.readthedocs.io/en/latest/index.html?highlight=sort#simplejson.dumps) or to [the standard lib one](https://docs.python.org/2/library/json.html#json.dumps). Both of them have `sort_keys=False` by default.

That's why I propose a new jsonify method in `jsonexportcommon.py`.