### PR TITLE
Return 404 if release missing, not 500

### DIFF
--- a/kickoff/test/views/test_releases.py
+++ b/kickoff/test/views/test_releases.py
@@ -130,6 +130,20 @@ class TestReleaseAPI(ViewTest):
         self.assertEquals(ret.content_type, 'text/plain')
         self.assertEquals(ret.data, 'ja zu')
 
+    def testGetL10n404(self):
+        ret = self.get('/releases/Firefox-2.0-build99/l10n')
+        self.assertEquals(ret.status_code, 404)
+
+    def testGetComment(self):
+        ret = self.get('/releases/Firefox-2.0-build1/comment')
+        self.assertEquals(ret.status_code, 200)
+        self.assertEquals(ret.content_type, 'text/plain')
+        self.assertEquals(ret.data, 'yet an other amazying comment')
+
+    def testGetComment404(self):
+        ret = self.get('/releases/Firefox-2.0-build99/comment')
+        self.assertEquals(ret.status_code, 404)
+
     def testResetReady(self):
         data = {'status': 'error!', 'ready': False}
         ret = self.post('/releases/Fennec-1-build1', data=data)

--- a/kickoff/views/releases.py
+++ b/kickoff/views/releases.py
@@ -206,15 +206,21 @@ class ReleasesListAPI(MethodView):
 class ReleaseL10nAPI(MethodView):
     def get(self, releaseName):
         table = getReleaseTable(releaseName)
-        l10n = table.query.filter_by(name=releaseName).first().l10nChangesets
-        return Response(status=200, response=l10n, content_type='text/plain')
+        release = table.query.filter_by(name=releaseName).first()
+        if not release:
+            abort(404)
+        return Response(status=200, response=release.l10nChangesets,
+                        content_type='text/plain')
 
 
 class ReleaseCommentAPI(MethodView):
     def get(self, releaseName):
         table = getReleaseTable(releaseName)
-        comment = table.query.filter_by(name=releaseName).first().comment
-        return Response(status=200, response=comment, content_type='text/plain')
+        release = table.query.filter_by(name=releaseName).first()
+        if not release:
+            abort(404)
+        return Response(status=200, response=release.comment,
+                        content_type='text/plain')
 
 
 class Releases(MethodView):


### PR DESCRIPTION
I found a couple of endpoints returning 500 if you try to access a missing release. 500 is rude, 404 is better. :)