### PR TITLE
bug 1223196 - include last RC in partial suggestsions for betas

### DIFF
--- a/kickoff/model.py
+++ b/kickoff/model.py
@@ -123,7 +123,7 @@ class Release(object):
         """Returns all shipped releases of 'age' or newer."""
         since = datetime.now() - age
         return [
-            r for r in cls.query.filter(cls._submittedAt > since).filter(cls._shippedAt != None).all()
+            r for r in cls.query.filter(cls._shippedAt > since).filter(cls._shippedAt != None).order_by(cls._shippedAt).all()
         ]
 
     @classmethod

--- a/kickoff/static/suggestions.js
+++ b/kickoff/static/suggestions.js
@@ -207,8 +207,9 @@ function populatePartial(productName, version, previousBuilds, partialElement) {
     if (isFirefox(productName) && version.match(/^\d+\.0$/)) {
         betaBuilds = previousBuilds[base + 'beta'];
         if (betaBuilds) {
-            // this relies on the order of releases reported by the DB, newest first
-            partial.unshift(betaBuilds[0]);
+            // we use addLastVersionAsPartial() to avoid duplicates
+            lastBeta = addLastVersionAsPartial(version, betaBuilds, 1);
+            partial.unshift(lastBeta);
             partialAdded++;
         } else {
             console.warn('Expected to add a beta release but none were found');

--- a/kickoff/static/suggestions.js
+++ b/kickoff/static/suggestions.js
@@ -143,7 +143,7 @@ function populatePartial(productName, version, previousBuilds, partialElement) {
 
     betaVersion = version.match(REGEXES.beta);
     if (betaVersion != null && typeof previousBuilds !== 'undefined' && typeof previousBuilds[base + 'beta'] !== 'undefined') {
-        previousReleases = previousBuilds[base + 'beta'].sort().reverse();
+        previousReleases = previousBuilds[base + 'beta'];
         nbPartial = 3;
         // Copy the global variable
         // For now, this is pretty much useless as we don't have metrics for specific beta
@@ -161,7 +161,7 @@ function populatePartial(productName, version, previousBuilds, partialElement) {
             base = guessBranchFromVersion(productName, version);
             if (typeof previousBuilds[base] !== 'undefined') {
                 // If the branch is not supported, do not try to access it
-                previousReleases = previousBuilds[base].sort().reverse();
+                previousReleases = previousBuilds[base];
             }
         } else {
             previousReleases = previousBuilds[base + 'release'];

--- a/kickoff/test/base.py
+++ b/kickoff/test/base.py
@@ -45,7 +45,7 @@ class TestBase(unittest.TestCase):
                                mozillaRelbranch='FOO',
                                submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
                                shippedAt=datetime(2005, 1, 4, 3, 4, 5, 6),
-                               comment="yet an other amazying comment",
+                               comment="yet an other amazing comment",
                                mh_changeset='xyz')
             r.complete = True
             r.ready = True
@@ -59,7 +59,7 @@ class TestBase(unittest.TestCase):
                                mozillaRelbranch='FOO',
                                submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
                                shippedAt=datetime(2005, 1, 4, 3, 4, 5, 6),
-                               comment="yet an other amazying comment")
+                               comment="yet an other amazing comment")
             r.complete = True
             r.ready = True
             r.status = "shipped"
@@ -72,7 +72,7 @@ class TestBase(unittest.TestCase):
                                mozillaRelbranch='FOO',
                                submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
                                shippedAt=datetime(2015, 1, 4, 3, 4, 5, 6),
-                               comment="yet an other amazying comment")
+                               comment="yet an other amazing comment")
             r.complete = True
             r.ready = True
             r.status = "shipped"
@@ -118,7 +118,7 @@ class TestBase(unittest.TestCase):
                                mozillaRelbranch='FOO',
                                submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
                                shippedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
-                               comment="yet an other amazying comment",
+                               comment="yet an other amazing comment",
                                isSecurityDriven=True,
                                description="We did this because of an issue in NSS")
             r.complete = True
@@ -132,7 +132,7 @@ class TestBase(unittest.TestCase):
                                l10nChangesets='ja zu',
                                mozillaRelbranch='FOO',
                                submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
-                               comment="yet an other amazying comment")
+                               comment="yet an other amazing comment")
             db.session.add(r)
 
             r = FirefoxRelease(partials='0,1', promptWaitTime=5,
@@ -142,7 +142,7 @@ class TestBase(unittest.TestCase):
                                mozillaRelbranch='FOO',
                                submittedAt=datetime(2005, 2, 3, 4, 5, 6, 7),
                                shippedAt=datetime(2005, 2, 3, 4, 5, 6, 7),
-                               comment="yet an other amazying comment",
+                               comment="yet an other amazing comment",
                                isSecurityDriven=True,
                                description="Another beta release for Firefox 3")
             r.complete = True
@@ -157,7 +157,7 @@ class TestBase(unittest.TestCase):
                                mozillaRelbranch='FOO',
                                submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
                                shippedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
-                               comment="yet an other amazying comment",
+                               comment="yet an other amazing comment",
                                description="we did this release because of foo")
             r.complete = True
             r.ready = True
@@ -190,7 +190,6 @@ class TestBase(unittest.TestCase):
                                    submittedAt=datetime(2005, 1, 1, 1, 1, 1, 1),
                                    description="foo reason")
             db.session.add(r)
-            db.session.commit()
 
             r = ThunderbirdRelease(commRevision='zzz', commRelbranch=None,
                                    partials='1.0build1', promptWaitTime=None,
@@ -205,7 +204,6 @@ class TestBase(unittest.TestCase):
             r.ready = True
             r.status = "shipped"
             db.session.add(r)
-            db.session.commit()
 
             r = ThunderbirdRelease(commRevision='zzz', commRelbranch=None,
                                    partials='1.0build1', promptWaitTime=None,
@@ -220,7 +218,6 @@ class TestBase(unittest.TestCase):
             r.ready = True
             r.status = "shipped"
             db.session.add(r)
-            db.session.commit()
 
             r = ThunderbirdRelease(commRevision='zzz', commRelbranch=None,
                                    partials='1.0build1', promptWaitTime=None,
@@ -235,6 +232,7 @@ class TestBase(unittest.TestCase):
             r.ready = True
             r.status = "shipped"
             db.session.add(r)
+
             db.session.commit()
 
     def tearDown(self):

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -209,7 +209,7 @@ var result = populatePartial("firefox", "39.0", previousBuilds, partialElement);
 assert.ok( result );
 assert.strictEqual($('#partials').val(), "38.0.3build2,35.0build2,36.0build2");
 
-// Test the case we had during the 38 cycle (ship-it didn't understood that 38.0.5b3 was a beta)
+// Test the case we had during the 38 cycle (ship-it didn't understand that 38.0.5b3 was a beta)
 allPartialJ='{"release": [{"version": "38.0.3", "ADI": 5000}, {"version": "35.0", "ADI": 3000}, {"version": "36.0", "ADI": 500}]}';
 allPartial=JSON.parse(allPartialJ);
 
@@ -370,6 +370,9 @@ QUnit.test('isStrictlyPreviousTo() must compare different version numbers', func
         { previous: '32.1.0', next: '32.1.1' },
         { previous: '32.1.0build1', next: '32.1.0build2' },
 
+        { previous: '32.0b10', next: '32.0'},
+        { previous: '32.0', next: '33.0b1'},
+
         { previous: '32.0b1', next: '33.0b1' },
         { previous: '32.0b1', next: '32.0b2' },
         { previous: '32.0b1build1', next: '32.0b1build2' },
@@ -414,7 +417,7 @@ QUnit.test('isStrictlyPreviousTo() must throw errors when not comparable', funct
     var data = [
         { a: '32.0', b: '32.0a1' },
         { a: '32.0', b: '32.0a2' },
-        { a: '32.0', b: '32.0b1' },
+        // comparing '32.0' to '32.0b1' is permitted
         { a: '32.0', b: '32.0esr' },
 
         { a: '32.0a1', b: '32.0a2' },

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -232,6 +232,19 @@ var result = populatePartial("firefox", "49.0", previousBuilds, partialElement);
 assert.ok( result );
 assert.strictEqual($('#partials').val(), "49.0b10build1,48.0.1build1,48.0build2");
 
+// Test case for early beta builds for Firefox, where we include the last RC in the list of partials
+allPartialJ='{"release": [{"version": "48.0.1", "ADI": 5000}, {"version": "48.0", "ADI": 1000}, {"version": "47.0.1", "ADI": 750}, {"version": "47.0", "ADI": 500}],' +
+            ' "beta": [{"version": "48.0.0b10", "ADI": 951}, {"version": "48.0b9", "ADI": 879}, {"version": "48.0b8", "ADI": 776}, {"version": "48.0b7"}]}';
+allPartial=JSON.parse(allPartialJ);
+
+previousBuilds = {"releases/mozilla-release": ["48.0.1build1", "48.0build2", "47.0.1build2",  "47.0build3"],
+                  "releases/mozilla-beta":    ["48.0build2", "48.0b10build1", "48.0b9build1", "48.0b8build2", "48.0b7build1"]}
+
+partialElement = $('#partials');
+var result = populatePartial("firefox", "49.0b1", previousBuilds, partialElement);
+assert.ok( result );
+assert.strictEqual($('#partials').val(), "48.0build2,48.0b10build1,48.0b9build1");
+
 });
 
 QUnit.test('getElmoUrl()', function(assert) {

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -147,9 +147,9 @@ allPartialJ='{"release": [{"version": "32.0.1", "ADI": 949}, {"version": "31.0",
             ' "esr": [{"version": "31.1.0esr", "ADI": 833}, {"version": "29.4.0esr", "ADI": 763}, {"version": "24.3.0esr", "ADI": 624}, {"version": "29.0esr", "ADI": 558}, {"version": "31.3.0esr", "ADI": 368}]}';
 allPartial=JSON.parse(allPartialJ);
 
-previousBuilds = {"releases/mozilla-beta": ["31.0b3build4", "31.0b2build2", "30.0b9build2", "29.0b10build2", "25.0b5build2", "30.0b2build1" ],
-                  "releases/mozilla-release": ["33.0.1build2", "31.1.0build2", "32.0.1build2", "31.0build2", "28.0build2", "27.0build2", "29.0build2", "30.0.5build7"],
-                  "releases/mozilla-esr31": ["31.1.0esrbuild1", "29.4.0esrbuild1", "29.2.0esrbuild1", "24.3.0esrbuild1", "29.0esrbuild1", "31.3.0esrbuild1" ]};
+previousBuilds = {"releases/mozilla-beta": ["31.0b3build4", "31.0b2build2", "30.0b9build2", "30.0b2build1", "29.0b10build2", "25.0b5build2"],
+                  "releases/mozilla-release": ["33.0.1build2", "32.0.1build2",  "31.1.0build2", "31.0build2", "30.0.5build7", "29.0build2", "28.0build2", "27.0build2"],
+                  "releases/mozilla-esr31": ["31.3.0esrbuild1", "31.1.0esrbuild1", "29.4.0esrbuild1", "29.2.0esrbuild1", "29.0esrbuild1", "24.3.0esrbuild1"]};
 
 partialElement = $('#partials');
 partialElement.hide();
@@ -178,7 +178,7 @@ assert.ok( result );
 assert.strictEqual($('#partials').val(), "31.1.0esrbuild1");
 
 // Thunderbird
-previousBuilds = {"releases/comm-esr31": ["31.0build1", "24.1.0build1", "24.3.0build1", "24.4.0build1"]},
+previousBuilds = {"releases/comm-esr31": ["31.0build1", "24.4.0build1", "24.3.0build1", "24.1.0build1"]},
 
 partialElement = $('#partials');
 var result = populatePartial("thunderbird", "31.2.0", previousBuilds, partialElement);

--- a/kickoff/test/test_model.py
+++ b/kickoff/test/test_model.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
+import mock
 
 from kickoff import app
 from kickoff.model import FennecRelease
@@ -12,3 +13,10 @@ class TestRelease(TestBase):
             # These two fennec build don't have any date.
             # Ship-it will consider today's date
             self.assertEquals(['Fennec-1-build1', 'Fennec-4-build4'], got)
+
+    def testGetRecentShipped(self):
+        with app.test_request_context():
+            with mock.patch('kickoff.model.datetime') as mock_datetime:
+                mock_datetime.now.return_value = datetime(2015, 3, 1)
+                got = [r.name for r in FennecRelease.getRecentShipped(age=timedelta(days=2))]
+                self.assertEquals(['Fennec-23.0b2-build4', 'Fennec-24.0-build4'], got)

--- a/kickoff/test/views/test_forms.py
+++ b/kickoff/test/views/test_forms.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+import json
+import mock
+import os
+from tempfile import mkstemp
+import unittest
+
+from kickoff import app, db
+from kickoff.log import cef_config
+from kickoff.model import FirefoxRelease, ThunderbirdRelease
+from kickoff.views.forms import FirefoxReleaseForm, ThunderbirdReleaseForm
+
+
+class TestFirefoxReleaseForm(unittest.TestCase):
+    def setUp(self):
+        self.cef_fd, self.cef_file = mkstemp()
+        app.config['DEBUG'] = True
+        app.config['CSRF_ENABLED'] = False
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        app.config.update(cef_config(self.cef_file))
+        with app.test_request_context():
+            db.init_app(app)
+            db.create_all()
+
+            for i, version in enumerate(('48.0b7', '48.0b8', '48.0b9', '48.0', '48.0.1',
+                                         '49.0b1', '49.0b2', '49.0b3')):
+                branch = 'releases/mozilla-beta'
+                if 'b' not in version:
+                    branch = 'releases/mozilla-release'
+                r = FirefoxRelease(partials='0,1', promptWaitTime=5,
+                                   submitter='joe', version=version, buildNumber=1,
+                                   branch=branch,
+                                   mozillaRevision='def',
+                                   l10nChangesets='ja zu',
+                                   mozillaRelbranch='FOO',
+                                   submittedAt=datetime(2015, 1, i+1, 3, 4, 5, 6),
+                                   shippedAt=datetime(2015, 1, i+1, 7, 8, 9, 0),
+                                   comment="yet an other amazing comment",
+                                   description="we did this release because of foo")
+                r.complete = True
+                r.ready = True
+                r.status = "shipped"
+                db.session.add(r)
+
+                r = ThunderbirdRelease(commRevision='zzz', commRelbranch=None,
+                                       partials='0,1', promptWaitTime=5,
+                                       submitter='joe', version=version, buildNumber=1,
+                                       branch=branch, mozillaRevision='def',
+                                       l10nChangesets='ja zu',
+                                       mozillaRelbranch='FOO',
+                                       submittedAt=datetime(2015, 1, i+1, 3, 4, 5, 6),
+                                       shippedAt=datetime(2015, 1, i+1, 7, 8, 9, 0),
+                                       comment="yet an other amazing comment",
+                                       description="we did this release because of foo")
+                r.complete = True
+                r.ready = True
+                r.status = "shipped"
+                db.session.add(r)
+
+            db.session.commit()
+
+    def tearDown(self):
+        # Trick Flask into thinking nothing has happened yet. Otherwise it will
+        # complain when we try to reset the state in setUp().
+        app._got_first_request = False
+        os.close(self.cef_fd)
+        os.remove(self.cef_file)
+
+    def testFirefoxRCInsertion(self):
+        with app.test_request_context():
+            with mock.patch('kickoff.model.datetime') as mock_datetime:
+                mock_datetime.now.return_value = datetime(2015, 2, 1)
+                release = FirefoxReleaseForm()
+                expected = json.dumps({
+                    "releases/mozilla-beta": ["49.0b3build1", "49.0b2build1", "49.0b1build1", "48.0build1", "48.0b9build1", "48.0b8build1", "48.0b7build1"],
+                    "releases/mozilla-release": ["48.0.1build1", "48.0build1"]
+                })
+                self.assertEqual(expected, release.partials.suggestions)
+
+    def testThunberbird(self):
+        with app.test_request_context():
+            with mock.patch('kickoff.model.datetime') as mock_datetime:
+                mock_datetime.now.return_value = datetime(2015, 2, 1)
+                release = ThunderbirdReleaseForm()
+                expected = json.dumps({
+                    "releases/mozilla-beta": ["49.0b3build1", "49.0b2build1", "49.0b1build1", "48.0b9build1", "48.0b8build1", "48.0b7build1"],
+                    "releases/mozilla-release": ["48.0.1build1", "48.0build1"]
+                })
+                self.assertEqual(expected, release.partials.suggestions)

--- a/kickoff/test/views/test_releases.py
+++ b/kickoff/test/views/test_releases.py
@@ -83,7 +83,7 @@ class TestReleaseAPI(ViewTest):
             'submittedAt': pytz.utc.localize(datetime.datetime(2005, 1, 2, 3, 4, 5, 6)).isoformat(),
             'version': '2.0',
             'buildNumber': 1,
-            'comment': 'yet an other amazying comment',
+            'comment': 'yet an other amazing comment',
             'branch': 'a',
             'mozillaRevision': 'def',
             'description': None,
@@ -138,7 +138,7 @@ class TestReleaseAPI(ViewTest):
         ret = self.get('/releases/Firefox-2.0-build1/comment')
         self.assertEquals(ret.status_code, 200)
         self.assertEquals(ret.content_type, 'text/plain')
-        self.assertEquals(ret.data, 'yet an other amazying comment')
+        self.assertEquals(ret.data, 'yet an other amazing comment')
 
     def testGetComment404(self):
         ret = self.get('/releases/Firefox-2.0-build99/comment')

--- a/kickoff/views/forms.py
+++ b/kickoff/views/forms.py
@@ -316,15 +316,20 @@ class DesktopReleaseForm(ReleaseForm):
         table = getReleaseTable(self.product.data)
         recentReleases = table.getRecentShipped()
         seenVersions = []
-        partials = {}
+        partials = defaultdict(list)
         # The UI will suggest any versions which are on the same branch as
         # the one given, but only the highest build number for that version.
+        # One exception is Firefox RC builds (version X.0), which should be added
+        # to the list of betas
         for release in reversed(recentReleases):
-            if release.branch not in partials:
-                partials[release.branch] = []
             if release.version not in seenVersions:
                 partials[release.branch].append('%sbuild%d' % (release.version, release.buildNumber))
                 seenVersions.append(release.version)
+                # here's the exception
+                if release.product == 'firefox' and \
+                   release.branch == 'releases/mozilla-release' and \
+                   re.match('^\d+\.0$', release.version):
+                    partials['releases/mozilla-beta'].append('%sbuild%d' % (release.version, release.buildNumber))
         self.partials.suggestions = json.dumps(partials)
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,4 +3,5 @@ Paste==1.7.5.1
 coverage
 rednose
 ordereddict
+mock
 


### PR DESCRIPTION
There's two things going on here.

1.  In creating the html for the release submission page (forms.py), we start inserting the RC build in the list of betas (caveat: only once it has shipped to release users, as there's no state to track shipped to beta users). To support this we start sorting the output of getRecentShipped() by shippedAt (ascending , see model.py). Tests for these changes in test_model.py & test_forms.py.

2. In the javascript side, I've modified Johan's Release objects to allow comparison between beta and release versions, otherwise we can't construct the list of partials on the fly (see release.js).

There's an 'amazying' test fix, and an improvement on bug 1177235 which ride along too. The individual commits may help decipher, particularly for suggestions.js and tests.js.
