### PR TITLE
Fix 52.0esr not being shown in firefox_version.json

### DIFF
--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -65,9 +65,9 @@ def getFilteredReleases(product, categories, ESR_NEXT=False, lastRelease=None,
             return
         if ESR_NEXT:
             # Ugly hack to manage the next ESR (when we have two overlapping esr)
-            version.append(("esr", "(" + config.ESR_NEXT + r"\.[0-9]+\.[0-9]+esr$|" + config.ESR_NEXT + r"\.[0-9]+\.[0-9]+\.[0-9]+esr$)"))
+            version.append(("esr", config.ESR_NEXT + r"(\.[0-9]+){1,2}esr$"))
         else:
-            version.append(("esr", "(" + config.CURRENT_ESR + r"\.[0-9]+\.[0-9]+esr$|" + config.CURRENT_ESR + r"\.[0-9]+\.[0-9]+\.[0-9]+esr$)"))
+            version.append(("esr", config.CURRENT_ESR + r"(\.[0-9]+){1,2}esr$"))
     releases = getReleases(ready=True, productFilter=product, versionFilterCategory=version, lastRelease=lastRelease)
     results = []
     for r in releases:


### PR DESCRIPTION
We need a test to prevent this regression, but this patch is a blocker to 52.0esr release. I prefer to handle the test in a follow up.

Basically 52.0esr has been filtered out by this regex