### PR TITLE
Bump versions for Thunderbird nightly @ 55

### DIFF
--- a/kickoff/config.py
+++ b/kickoff/config.py
@@ -1,8 +1,8 @@
 # To make flake8 happy
 NIGHTLY_VERSION = "55.0a1"
 AURORA_VERSION = "53.0a2"
-LATEST_THUNDERBIRD_NIGHTLY_VERSION = "54.0a1"
-LATEST_THUNDERBIRD_ALPHA_VERSION = "53.0a2"
+LATEST_THUNDERBIRD_NIGHTLY_VERSION = "55.0a1"
+LATEST_THUNDERBIRD_ALPHA_VERSION = "54.0a2"
 SUPPORTED_AURORA_LOCALES = ['ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg', 'bn-BD', 'bn-IN', 'br', 'bs', 'ca', 'cak', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en-GB', 'en-US', 'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gn', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja', 'ja-JP-mac', 'ka', 'kab', 'kk', 'km', 'kn', 'ko', 'lij', 'lt', 'ltg', 'lv', 'mai', 'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'ne-NP', 'nl', 'nn-NO', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'si', 'sk', 'sl', 'sq', 'son', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'uz', 'vi', 'xh', 'zh-CN', 'zh-TW']
 SUPPORTED_NIGHTLY_LOCALES = ['ar', 'ast', 'cs', 'de', 'en-GB', 'en-US', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'fa', 'fr', 'fy-NL', 'gl', 'he', 'hu', 'id', 'it', 'ja', 'ja-JP-mac', 'kk', 'ko', 'lt', 'lv', 'nb-NO', 'nl', 'nn-NO', 'pl', 'pt-BR', 'pt-PT', 'ru', 'sk', 'sl', 'sv-SE', 'th', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
 LATEST_FIREFOX_OLDER_VERSION = "3.6.28"


### PR DESCRIPTION
Sets Thunderbird nightlies to 55.0a1 and Thunderbird aurora to 54.0a2.

Also it looks like Firefox aurora is still at 53.0a2, not sure if it's supposed to be at 54.0a2 yet or not!