### PR TITLE
Bump version for Thunderbird 56.

### DIFF
--- a/kickoff/config.py
+++ b/kickoff/config.py
@@ -1,6 +1,6 @@
 # To make flake8 happy
 NIGHTLY_VERSION = "56.0a1"
-LATEST_THUNDERBIRD_NIGHTLY_VERSION = "55.0a1"
+LATEST_THUNDERBIRD_NIGHTLY_VERSION = "56.0a1"
 LATEST_THUNDERBIRD_ALPHA_VERSION = "54.0a2"
 SUPPORTED_NIGHTLY_LOCALES = ['ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg', 'bn-BD', 'bn-IN', 'br', 'bs', 'ca', 'cak', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en-GB', 'en-US', 'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gn', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja', 'ja-JP-mac', 'ka', 'kab', 'kk', 'km', 'kn', 'ko', 'lij', 'lo', 'lt', 'ltg', 'lv', 'mai', 'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'ne-NP', 'nl', 'nn-NO', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'si', 'sk', 'sl', 'sq', 'son', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'uz', 'vi', 'xh', 'zh-CN', 'zh-TW']
 LATEST_FIREFOX_OLDER_VERSION = "3.6.28"


### PR DESCRIPTION
This bumps the Thunderbird version to 56, which is the current nightly version.

What is supposed to be being done with the `LATEST_THUNDERBIRD_ALPHA_VERSIOn`? Aurora is no longer being used...so I feel like this probably is unused, but I don't know how these values propagate into other apps?