### PR TITLE
Change the local name of Lithuanian language.

### DIFF
--- a/kickoff/static/languages.json
+++ b/kickoff/static/languages.json
@@ -353,7 +353,7 @@
     },
     "lt": {
         "English": "Lithuanian",
-        "native": "lietuvi\u0173 kalba"
+        "native": "Lietuvi\u0173"
     },
     "ltg": {
         "English": "Latgalian",


### PR DESCRIPTION
This fixes Bugzilla bug #1381207: https://bugzilla.mozilla.org/show_bug.cgi?id=1381207.