### PR TITLE
Bug 1385076 - Add Highland Puebla Nahuatl (azz) to languages.json

### DIFF
--- a/kickoff/static/languages.json
+++ b/kickoff/static/languages.json
@@ -35,6 +35,10 @@
         "English": "Azerbaijani",
         "native": "Az\u0259rbaycanca"
     },
+    "azz": {
+        "English": "Highland Puebla Nahuatl",
+        "native": "nahuatl sierra norte Puebla"
+    },
     "be": {
         "English": "Belarusian",
         "native": "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f"


### PR DESCRIPTION
Locale is only localizing mozilla.org, and languages.json is used for the language switcher