### PR TITLE
Bug 1415288 - devedition builds missing from firefox_primary_builds.json

### DIFF
--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -231,6 +231,14 @@ def updateLocaleWithVersionsTable(product):
     betas = getFilteredReleases(product, ["dev"], lastRelease=True, withL10N=True)
     buildsVersionLocales = generateLocalizedBuilds(buildsVersionLocales,
                                                    betas[0][2], betas[0][0])
+
+    # devedition (now based on beta)
+    # Most of the time, beta == deveditions but not always ...
+    if product == 'firefox':
+        deveditions = getFilteredReleases("devedition", ["dev"], lastRelease=True, withL10N=True)
+        buildsVersionLocales = generateLocalizedBuilds(buildsVersionLocales,
+                                                       deveditions[0][2], deveditions[0][0])
+
     # esr
     esr_releases = getFilteredReleases(product, ["esr"], lastRelease=True, withL10N=True)
     buildsVersionLocales = generateLocalizedBuilds(buildsVersionLocales,

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -106,12 +106,13 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(len(primary['fr']), 2)
         # We always have en-US for all channels
         self.assertTrue('24.0a1' in primary['en-US'])
-        self.assertTrue('3.0b3' in primary['en-US'])
-        self.assertTrue('3.0.1' in primary['en-US'], primary['en-US'])
+        self.assertTrue('3.0b3' in primary['en-US'])   # beta
+        self.assertTrue('3.0b5' in primary['en-US'])   # deved
+        self.assertTrue('3.0.1' in primary['en-US'], primary['en-US']) # release
         # Verify ESR numbers are well-formed and both esr/esr_next are present
         self.assertTrue('2.0.2esr' in primary['en-US'])
         self.assertTrue('38.0esr' in primary['en-US'])
-        self.assertEquals(len(primary['en-US']), 6)
+        self.assertEquals(len(primary['en-US']), 7)
         # ja-JP-mac is not a locale we want to expose into product-details
         self.assertFalse('ja-JP-mac' in primary)
 


### PR DESCRIPTION
Adds a special case to updateLocaleWithVersionsTable() to lookup deved releases when the product is 'firefox'. testPrimaryBuilds() checks the case where deved and beta have different last versions (3.0b5 and 3.0b3 respectively). testPrimaryBuildsDegenerateDevedAndBeta() adds a beta 3.0b5 release, to handle the case later in the cycle and they match each other (essentially making sure generateLocalizedBuilds() combines things properly).