### PR TITLE
Bug 1415268 - part2: Prevent front-end to add too many partials

### DIFF
--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -82,7 +82,7 @@ assert.strictEqual( guessBranchFromVersion("firefox", "31.0.1esr"), "releases/mo
 
 ///////////////////////////////////////////////////
 
-QUnit.test( "addLastVersionAsPartial", function( assert ) {
+QUnit.test( "craftLastReleasesAsPartials", function( assert ) {
     name="firefox";
     base = getBaseRepository(name);
     previousBuilds = {
@@ -96,14 +96,14 @@ QUnit.test( "addLastVersionAsPartial", function( assert ) {
     };
 
     previousReleases = previousBuilds[base + 'release'].sort().reverse();
-    assert.deepEqual( addLastVersionAsPartial("35.0", previousReleases, 1), ["33.0.1build2"]);
+    assert.deepEqual( craftLastReleasesAsPartials("35.0", previousReleases, 1), ["33.0.1build2"]);
 
     previousReleases = previousBuilds[base + 'beta'].sort().reverse();
-    assert.deepEqual( addLastVersionAsPartial("35.0b2", previousReleases, 1), ["31.0b2build2"]);
-    assert.deepEqual( addLastVersionAsPartial("48.0b10", previousReleases, 3), ["48.0b9build1", "48.0b7build1", "48.0b6build1"]);
+    assert.deepEqual( craftLastReleasesAsPartials("35.0b2", previousReleases, 1), ["31.0b2build2"]);
+    assert.deepEqual( craftLastReleasesAsPartials("48.0b10", previousReleases, 3), ["48.0b9build1", "48.0b7build1", "48.0b6build1"]);
 
     previousReleases = previousBuilds[base + 'esr31'].sort().reverse();
-    assert.deepEqual( addLastVersionAsPartial("38.0esr", previousReleases, 1), ["31.1.0esrbuild1"]);
+    assert.deepEqual( craftLastReleasesAsPartials("38.0esr", previousReleases, 1), ["31.1.0esrbuild1"]);
 });
 
 

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -245,6 +245,18 @@ var result = populatePartial("firefox", "49.0b1", previousBuilds, partialElement
 assert.ok( result );
 assert.strictEqual($('#partials').val(), "48.0build2,48.0b10build1,48.0b9build1");
 
+// Verify only 1 ESR build remains. In bug 1415268, we realized too many partials were added.
+// This was caused by allPartialJ are ordered by number of ADIs (instead by release number).
+allPartialJ='{"esr": [{"version": "52.4.0esr", "ADI": 5000}, {"version": "52.3.0esr", "ADI": 4000}, {"version": "52.4.1esr", "ADI": 3000}]}';
+allPartial=JSON.parse(allPartialJ);
+
+previousBuilds = {"releases/mozilla-esr52": ["52.4.1esrbuild1", "52.4.0esrbuild2", "52.3.0esrbuild2"]}
+
+partialElement = $('#partials');
+var result = populatePartial("firefox", "52.5.0esr", previousBuilds, partialElement);
+assert.ok( result );
+assert.strictEqual($('#partials').val(), "52.4.1esrbuild1");
+
 });
 
 QUnit.test('getElmoUrl()', function(assert) {


### PR DESCRIPTION
I think I found what's wrong. The partial list is loaded from https://ship-it.mozilla.org/cron/partial.json. That file is overwritten regularly. Lastly, it probably wasn't ordered the was it used to be. Earlier today, I was able to reproduce this problem against the prod environment. After a few hours, I became unable.

I saw the number of partials exploding. I firmly believe this is because we [entered this loop](https://github.com/mozilla-releng/ship-it/pull/207/files#diff-f2f19f23c632c1a8154fd734bebd6ed1L223), while we already had a partial defined. That's why it didn't exit thanks to [that break condition](https://github.com/mozilla-releng/ship-it/pull/207/files#diff-f2f19f23c632c1a8154fd734bebd6ed1L232).

To sum up, this PR:
* checks each time we add new partials if we reached the maximum numbers of partials. This is what fixes the bug.
* Then for clarity: it renames `partial` into `partials` since it's an array of several partials
* renames `addLastVersionAsPartial` into `craftLastReleasesAsPartials` because it doesn't add anything to any existing data structure. It just returns an array of strings.
* renames `nbPartial` into `maximumNumberOfPartials` to be explicit about the intent behind this int.