### PR TITLE
Add devedition.json, and build_number to product exports

### DIFF
--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -87,6 +87,7 @@ def getFilteredReleases(product, categories, esrNext=False, lastRelease=None,
         else:
             if detailledInfo:
                 results.append({"version": version,
+                                "buildNumber": r.buildNumber,
                                 "shippedAt": shippedAt,
                                 "versionDetailled": r.version,
                                 "category": r.category,
@@ -395,6 +396,7 @@ def getReleasesForJson(product):
             "date": r["shippedAt"],
             "version": r["version"],
             "product": product,
+            "build_number": r["buildNumber"],
             "category": category,
             "description": r["description"],
             "is_security_driven": r["isSecurityDriven"] is True

--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -413,6 +413,13 @@ def jsonFirefoxExport():
     return jsonify_by_sorting_values(release_list, detailledJson=True)
 
 
+@app.route(BASE_JSON_PATH + '/devedition.json', methods=['GET'])
+def jsonDeveditionExport():
+    """ Export all the devedition versions """
+    release_list = getReleasesForJson("devedition")
+    return jsonify_by_sorting_values(release_list, detailledJson=True)
+
+
 @app.route(BASE_JSON_PATH + '/mobile_android.json', methods=['GET'])
 def jsonFennecExport():
     """ Export all the fennec versions """
@@ -433,6 +440,6 @@ def jsonAllExport():
     release_list = {
         "releases": {}
     }
-    for release in ("firefox", "fennec", "thunderbird"):
+    for release in ("devedition", "firefox", "fennec", "thunderbird"):
         release_list["releases"].update(getReleasesForJson(release)["releases"])
     return jsonify_by_sorting_values(release_list, detailledJson=True)

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -306,6 +306,7 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['version'], "3.0b2")
         self.assertEquals(v['category'], "dev")
         self.assertEquals(v['product'], "firefox")
+        self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], True)
         self.assertEquals(v['description'], "We did this because of an issue in NSS")
         v = firefoxReleases['firefox-2.0.2esr']
@@ -313,6 +314,7 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['version'], "2.0.2")
         self.assertEquals(v['category'], "esr")
         self.assertEquals(v['product'], "firefox")
+        self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], False)
         self.assertEquals(v['description'], None)
 
@@ -328,6 +330,7 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['version'], "23.0")
         self.assertEquals(v['category'], "major")
         self.assertEquals(v['product'], "thunderbird")
+        self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], False)
         self.assertEquals(v['description'], "bar reason")
         v = thunderbirdReleases['thunderbird-24.0b2']
@@ -335,6 +338,7 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['version'], "24.0b2")
         self.assertEquals(v['category'], "dev")
         self.assertEquals(v['product'], "thunderbird")
+        self.assertEquals(v['build_number'], 2)
         self.assertEquals(v['is_security_driven'], False)
 
     def testFennec(self):
@@ -349,12 +353,14 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['version'], "23.0b2")
         self.assertEquals(v['category'], "dev")
         self.assertEquals(v['product'], "fennec")
+        self.assertEquals(v['build_number'], 4)
         self.assertEquals(v['is_security_driven'], False)
         v = fennecReleases['fennec-24.0']
         self.assertEquals(v['date'], "2015-03-01")
         self.assertEquals(v['version'], "24.0")
         self.assertEquals(v['category'], "major")
         self.assertEquals(v['product'], "fennec")
+        self.assertEquals(v['build_number'], 4)
         self.assertEquals(v['is_security_driven'], False)
 
     def testAll(self):
@@ -369,12 +375,14 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['version'], "3.0b2")
         self.assertEquals(v['category'], "dev")
         self.assertEquals(v['product'], "firefox")
+        self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], True)
         v = allReleases['firefox-2.0.2esr']
         self.assertEquals(v['date'], "2005-01-04")
         self.assertEquals(v['version'], "2.0.2")
         self.assertEquals(v['category'], "esr")
         self.assertEquals(v['product'], "firefox")
+        self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], False)
 
         self.assertTrue("thunderbird-23.0" in allReleases)
@@ -384,12 +392,14 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['version'], "23.0")
         self.assertEquals(v['category'], "major")
         self.assertEquals(v['product'], "thunderbird")
+        self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], False)
         v = allReleases['thunderbird-24.0b2']
         self.assertEquals(v['date'], "2005-02-01")
         self.assertEquals(v['version'], "24.0b2")
         self.assertEquals(v['category'], "dev")
         self.assertEquals(v['product'], "thunderbird")
+        self.assertEquals(v['build_number'], 2)
         self.assertEquals(v['is_security_driven'], False)
 
         self.assertTrue("fennec-23.0b2" in allReleases)
@@ -399,12 +409,14 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['version'], "23.0b2")
         self.assertEquals(v['category'], "dev")
         self.assertEquals(v['product'], "fennec")
+        self.assertEquals(v['build_number'], 4)
         self.assertEquals(v['is_security_driven'], False)
         v = allReleases['fennec-24.0']
         self.assertEquals(v['date'], "2015-03-01")
         self.assertEquals(v['version'], "24.0")
         self.assertEquals(v['category'], "major")
         self.assertEquals(v['product'], "fennec")
+        self.assertEquals(v['build_number'], 4)
         self.assertEquals(v['is_security_driven'], False)
 
     def test_esr_next_empty(self):

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -318,6 +318,21 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['is_security_driven'], False)
         self.assertEquals(v['description'], None)
 
+    def testDevedition(self):
+        ret = self.get(BASE_JSON_PATH + '/devedition.json')
+        deveditionReleases = json.loads(ret.data)
+        self.assertEquals(ret.status_code, 200)
+        deveditionReleases = deveditionReleases["releases"]
+        self.assertTrue("devedition-3.0b5" in deveditionReleases)
+        v = deveditionReleases['devedition-3.0b5']
+        self.assertEquals(v['date'], "2005-01-02")
+        self.assertEquals(v['version'], "3.0b5")
+        self.assertEquals(v['category'], "dev")
+        self.assertEquals(v['product'], "devedition")
+        self.assertEquals(v['build_number'], 1)
+        self.assertEquals(v['is_security_driven'], False)
+        self.assertEquals(v['description'], "we did this release because of foo")
+
     def testThunderbird(self):
         ret = self.get(BASE_JSON_PATH + '/thunderbird.json')
         thunderbirdReleases = json.loads(ret.data)
@@ -384,6 +399,16 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['product'], "firefox")
         self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], False)
+
+        self.assertTrue("devedition-3.0b5" in allReleases)
+        v = allReleases['devedition-3.0b5']
+        self.assertEquals(v['date'], "2005-01-02")
+        self.assertEquals(v['version'], "3.0b5")
+        self.assertEquals(v['category'], "dev")
+        self.assertEquals(v['product'], "devedition")
+        self.assertEquals(v['build_number'], 1)
+        self.assertEquals(v['is_security_driven'], False)
+        self.assertEquals(v['description'], "we did this release because of foo")
 
         self.assertTrue("thunderbird-23.0" in allReleases)
         self.assertTrue("thunderbird-24.0b2" in allReleases)


### PR DESCRIPTION
The main goal here is to make product-details.mozilla.org useful for update verify config generation - which means we need build number for each version, and a way to query devedition releases.

This was discussed with various stakeholders in e-mail a bit. There was some mild paranoia about changing these exports - but I think everyone agreed that because these are added changes, that it should be OK.

@kyoshino - you were cc'ed on the e-mail thread but didn't weigh in yet. Just want to make sure you're aware of this, in case you have thoughts.