### PR TITLE
Bug 1462120 - Firefox 60.0esr should be in firefox.json …

### DIFF
--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -50,7 +50,10 @@ def getFilteredReleases(product, categories, esrNext=False, lastRelease=None,
             special_majors = patternize_versions(SPECIAL_THUNDERBIRD_MAJORS)
         else:
             special_majors = patternize_versions(SPECIAL_FIREFOX_MAJORS)
-        version.append(("major", r"([0-9]+\.[0-9]+%s)$" % special_majors))
+        if exclude_esr:
+            version.append(("major", r"([0-9]+\.[0-9]+%s)$" % special_majors))
+        else:
+            version.append(("major", r"([0-9]+\.[0-9]+(esr|)%s)$" % special_majors))
     if "stability" in categories:
         if exclude_esr:
             version.append(("stability", r"([0-9]+\.[0-9]+\.[0-9]+$|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$)"))
@@ -115,8 +118,8 @@ BASE_JSON_PATH = '/json/' + JSON_VER
 
 @app.route(BASE_JSON_PATH + '/firefox_history_major_releases.json', methods=['GET'])
 def firefoxHistoryMajorReleasesJson():
-    # Match X.Y and 14.0.1 (special case)
-    values = getFilteredReleases("firefox", "major")
+    # Match X.Y and 14.0.1 (special case) but not ESR
+    values = getFilteredReleases("firefox", "major", exclude_esr=True)
     return jsonify_by_sorting_values(values)
 
 

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -301,6 +301,7 @@ class TestJSONRequestsAPI(ViewTest):
         firefoxReleases = firefoxReleases["releases"]
         self.assertTrue("firefox-3.0b2" in firefoxReleases)
         self.assertTrue("firefox-2.0.2esr" in firefoxReleases)
+        self.assertTrue("firefox-38.0esr" in firefoxReleases)
         v = firefoxReleases['firefox-3.0b2']
         self.assertEquals(v['date'], "2005-01-02")
         self.assertEquals(v['version'], "3.0b2")
@@ -317,6 +318,8 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], False)
         self.assertEquals(v['description'], None)
+        v = firefoxReleases['firefox-38.0esr']
+        self.assertEquals(v['category'], "esr")
 
     def testDevedition(self):
         ret = self.get(BASE_JSON_PATH + '/devedition.json')


### PR DESCRIPTION
…to create update verify configs.

I think this does the right thing - add 60.0esr into firefox.json but not modify firefox_history_major_releases.json at all. Basically it adds the exclude_esr behaviour to 'major', so that it's more like 'stability'.

@pmac - does it look OK to you too ?