### PR TITLE
Revert "Bug 1462120 - Firefox 60.0esr should be in firefox.json to cr…

### DIFF
--- a/kickoff/jsonexport.py
+++ b/kickoff/jsonexport.py
@@ -50,10 +50,7 @@ def getFilteredReleases(product, categories, esrNext=False, lastRelease=None,
             special_majors = patternize_versions(SPECIAL_THUNDERBIRD_MAJORS)
         else:
             special_majors = patternize_versions(SPECIAL_FIREFOX_MAJORS)
-        if exclude_esr:
-            version.append(("major", r"([0-9]+\.[0-9]+%s)$" % special_majors))
-        else:
-            version.append(("major", r"([0-9]+\.[0-9]+(esr|)%s)$" % special_majors))
+        version.append(("major", r"([0-9]+\.[0-9]+%s)$" % special_majors))
     if "stability" in categories:
         if exclude_esr:
             version.append(("stability", r"([0-9]+\.[0-9]+\.[0-9]+$|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$)"))
@@ -118,8 +115,8 @@ BASE_JSON_PATH = '/json/' + JSON_VER
 
 @app.route(BASE_JSON_PATH + '/firefox_history_major_releases.json', methods=['GET'])
 def firefoxHistoryMajorReleasesJson():
-    # Match X.Y and 14.0.1 (special case) but not ESR
-    values = getFilteredReleases("firefox", "major", exclude_esr=True)
+    # Match X.Y and 14.0.1 (special case)
+    values = getFilteredReleases("firefox", "major")
     return jsonify_by_sorting_values(values)
 
 

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -301,7 +301,6 @@ class TestJSONRequestsAPI(ViewTest):
         firefoxReleases = firefoxReleases["releases"]
         self.assertTrue("firefox-3.0b2" in firefoxReleases)
         self.assertTrue("firefox-2.0.2esr" in firefoxReleases)
-        self.assertTrue("firefox-38.0esr" in firefoxReleases)
         v = firefoxReleases['firefox-3.0b2']
         self.assertEquals(v['date'], "2005-01-02")
         self.assertEquals(v['version'], "3.0b2")
@@ -318,8 +317,6 @@ class TestJSONRequestsAPI(ViewTest):
         self.assertEquals(v['build_number'], 1)
         self.assertEquals(v['is_security_driven'], False)
         self.assertEquals(v['description'], None)
-        v = firefoxReleases['firefox-38.0esr']
-        self.assertEquals(v['category'], "esr")
 
     def testDevedition(self):
         ret = self.get(BASE_JSON_PATH + '/devedition.json')


### PR DESCRIPTION
…eate update verify configs (#222)" for busting Firefox beta releases (they try to include 60.0esr in the u.v. config).

This reverts commit 90794c58730ec20d00a184399f12b04cadc45484.