### PR TITLE
Handle "legacy" releases properly, kill python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,18 @@ sudo: false
 
 language: python
 python:
-  - "2.6"
   - "2.7"
 
 install:
     - travis_retry pip install tox-travis
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then travis_retry pip install flake8; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then travis_retry nvm install; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then travis_retry npm install; fi
+    - travis_retry pip install flake8
+    - travis_retry nvm install
+    - travis_retry npm install
 
 script:
     - tox
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then ./node_modules/.bin/grunt --verbose; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then flake8 kickoff/ --exclude=kickoff/test/ --max-line-length=2000 --ignore=E402,E711; fi
+    - ./node_modules/.bin/grunt --verbose
+    - flake8 kickoff/ --exclude=kickoff/test/ --max-line-length=2000 --ignore=E402,E711
 
 after_success:
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then travis_retry pip install coveralls && coveralls; fi
+    - travis_retry pip install coveralls && coveralls

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -q update && \
     apt-get -q --yes install \
         sqlite3 \
-        libmysqlclient-dev \
+        default-libmysqlclient-dev \
         mysql-client \
     && apt-get clean
 

--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,12 +1,15 @@
-FROM mozillareleases/python-test-runner
+FROM ubuntu
+MAINTAINER rail@mozilla.com
+ENV DEBIAN_FRONTEND=noninteractive
 
-MAINTAINER callek@mozilla.com
-
-RUN apt-get -q update && \
-    apt-get -q --yes install \
-        sqlite3 \
-        phantomjs \
-        npm \
+RUN apt-get -q update \
+    && apt-get install --yes -q \
+    libmysqlclient-dev \
+    npm \
+    phantomjs \
+    python-tox \
+    python-dev \
+    sqlite3 \
     && apt-get clean
 
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+COPY Dockerfile-tests /Dockerfile

--- a/kickoff/jsonexportl10n.py
+++ b/kickoff/jsonexportl10n.py
@@ -50,18 +50,19 @@ def _getLocalesByReleaseName(releaseTable, releaseName):
 
 
 def _getReleaseLocales(release):
-    if release is None or release.l10nChangesets == config.LEGACY_KEYWORD:
-        return jsonify_by_sorting_values({})
-
     locale_list = defaultdict()
-    if "Firefox" in release.name or "Thunderbird" in release.name:
+
+    if release is None or release.l10nChangesets == config.LEGACY_KEYWORD:
+        locale_list = {}
+
+    elif "Firefox" in release.name or "Thunderbird" in release.name:
         locales = parsePlainL10nChangesets(release.l10nChangesets)
         for key, changeset in locales.iteritems():
             locale_list[key] = {
                 "changeset": changeset,
             }
 
-    if "Fennec" in release.name:
+    elif "Fennec" in release.name:
         locales = json.loads(release.l10nChangesets)
         for key, extra in locales.iteritems():
             locale_list[key] = {

--- a/kickoff/test/base.py
+++ b/kickoff/test/base.py
@@ -117,6 +117,20 @@ class TestBase(unittest.TestCase):
             db.session.add(r)
 
             r = FirefoxRelease(partials='0,1', promptWaitTime=5,
+                               submitter='joe', version='1.0.9', buildNumber=1,
+                               branch='a', mozillaRevision='def',
+                               l10nChangesets='legacy',
+                               mozillaRelbranch='FOO',
+                               submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
+                               shippedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
+                               comment="yet an other amazing comment",
+                               description="we did this release because of foo")
+            r.complete = True
+            r.ready = True
+            r.status = "shipped"
+            db.session.add(r)
+
+            r = FirefoxRelease(partials='0,1', promptWaitTime=5,
                                submitter='joe', version='3.0b1', buildNumber=1,
                                branch='a', mozillaRevision='def',
                                l10nChangesets='ja zu',
@@ -176,20 +190,6 @@ class TestBase(unittest.TestCase):
                                submitter='joe', version='3.0.1', buildNumber=1,
                                branch='a', mozillaRevision='def',
                                l10nChangesets='ja zu',
-                               mozillaRelbranch='FOO',
-                               submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
-                               shippedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
-                               comment="yet an other amazing comment",
-                               description="we did this release because of foo")
-            r.complete = True
-            r.ready = True
-            r.status = "shipped"
-            db.session.add(r)
-
-            r = FirefoxRelease(partials='0,1', promptWaitTime=5,
-                               submitter='joe', version='3.0.9', buildNumber=1,
-                               branch='a', mozillaRevision='def',
-                               l10nChangesets='legacy',
                                mozillaRelbranch='FOO',
                                submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
                                shippedAt=datetime(2005, 1, 2, 3, 4, 5, 6),

--- a/kickoff/test/base.py
+++ b/kickoff/test/base.py
@@ -186,6 +186,20 @@ class TestBase(unittest.TestCase):
             r.status = "shipped"
             db.session.add(r)
 
+            r = FirefoxRelease(partials='0,1', promptWaitTime=5,
+                               submitter='joe', version='3.0.9', buildNumber=1,
+                               branch='a', mozillaRevision='def',
+                               l10nChangesets='legacy',
+                               mozillaRelbranch='FOO',
+                               submittedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
+                               shippedAt=datetime(2005, 1, 2, 3, 4, 5, 6),
+                               comment="yet an other amazing comment",
+                               description="we did this release because of foo")
+            r.complete = True
+            r.ready = True
+            r.status = "shipped"
+            db.session.add(r)
+
             r = DeveditionRelease(
                 partials='0,1', promptWaitTime=5, submitter='joe',
                 version='3.0b5', buildNumber=1, branch='a',

--- a/kickoff/test/views/test_json.py
+++ b/kickoff/test/views/test_json.py
@@ -39,6 +39,7 @@ class TestJSONRequestsAPI(ViewTest):
     def testStablityReleases(self):
         ret = self.get(BASE_JSON_PATH + '/firefox_history_stability_releases.json')
         expected = {
+            '1.0.9': '2005-01-02',
             '2.0.2': '2005-01-04',
             '3.0.1': '2005-01-02',
         }

--- a/kickoff/test/views/test_jsonl10n.py
+++ b/kickoff/test/views/test_jsonl10n.py
@@ -39,6 +39,7 @@ class TestJSONL10NRequestsAPI(ViewTest):
         self.assertTrue("Fennec-23.0b2-build4" in fileList)
         self.assertTrue("Thunderbird-24.0b2-build2.json" in fileList)
         self.assertTrue("Firefox-2.0-build1.json" in fileList)
+        self.assertTrue("Firefox-1.0.9-build1.json" not in fileList)
         # Check if we have duplicates of a given beta aggregation
         aggregated_entries = \
             [i for i, htmlLine in enumerate(fileList.split('<br />')) if "Firefox-3.0beta.json" in htmlLine]
@@ -53,6 +54,12 @@ class TestJSONL10NRequestsAPI(ViewTest):
 
         self.assertEquals(jsonFx['submittedAt'], pytz.utc.localize(datetime.datetime(2005, 1, 2, 3, 4, 5, 6)).isoformat())
         self.assertEquals(jsonFx['shippedAt'], pytz.utc.localize(datetime.datetime(2005, 1, 4, 3, 4, 5, 6)).isoformat())
+
+    def testJsonFileFXLegacy(self):
+        ret = self.get(BASE_JSON_PATH + '/l10n/Firefox-1.0.9-build1.json')
+        jsonFx = json.loads(ret.data)
+        self.assertEquals(ret.status_code, 200)
+        self.assertEquals(jsonFx["locales"], {})
 
     def testJsonFileFennec(self):
         ret = self.get(BASE_JSON_PATH + '/l10n/Fennec-24.0-build4.json')

--- a/kickoff/test/views/test_releases.py
+++ b/kickoff/test/views/test_releases.py
@@ -22,6 +22,7 @@ class TestRequestsAPI(ViewTest):
                          'Fennec-24.0.1-build4', 'Fennec-23.0b2-build4',
                          'Firefox-2.0-build1', "Firefox-2.0.2esr-build1",
                          'Firefox-38.0esr-build1',
+                         'Firefox-1.0.9-build1',
                          'Firefox-3.0b1-build1',
                          'Firefox-3.0b2-build1', 'Firefox-3.0b2-build2',
                          'Firefox-3.0b3-build1',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27
+envlist = py27
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
From last commit:
    When a release uses l10nChangesets: "legacy" (not available?), the
    corresponding function (_getReleaseLocales) returns a flask.Response
    object (generated by jsonify_by_sorting_values). This breaks the logic
    when we export aggregated (combined betas) release JSON files, because
    flask.Response is not JSON serializable.