### PR TITLE
Do not validate Thunderbird partials

### DIFF
--- a/kickoff/views/forms.py
+++ b/kickoff/views/forms.py
@@ -405,6 +405,8 @@ class ThunderbirdReleaseForm(DesktopReleaseForm):
     product = HiddenField('product')
     commRevision = StringField('Comm Revision:')
     commRelbranch = StringField('Comm Relbranch:', filters=[noneFilter])
+    # Do not validate Thunderbird partials, they are not implemented
+    partials = StringField('Partials:')
 
     def __init__(self, *args, **kwargs):
         ReleaseForm.__init__(self, prefix='thunderbird', product='thunderbird', *args, **kwargs)


### PR DESCRIPTION
Thunderbird partials are not implemented yet, but the validator from `DesktopReleaseForm` won't let you use an empty string if you have previous releases (`OptionalPartials`).

This should override the attribute, so it's not validated by the API and we don't get 400 errors tryning to submit v1 release data without faking the partials input.