### PR TITLE
Bump Thunderbird nightly version to 68.

### DIFF
--- a/kickoff/config.py
+++ b/kickoff/config.py
@@ -4,7 +4,7 @@
 # sync.
 # To make flake8 happy
 NIGHTLY_VERSION = "68.0a1"
-LATEST_THUNDERBIRD_NIGHTLY_VERSION = "67.0a1"
+LATEST_THUNDERBIRD_NIGHTLY_VERSION = "68.0a1"
 LATEST_THUNDERBIRD_ALPHA_VERSION = "54.0a2"
 SUPPORTED_NIGHTLY_LOCALES = ['ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg', 'bn-BD', 'bn-IN', 'br', 'bs', 'ca', 'cak', 'crh', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en-CA', 'en-GB', 'en-US', 'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gn', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb', 'hu', 'hy-AM', 'ia', 'id', 'is', 'it', 'ja', 'ja-JP-mac', 'ka', 'kab', 'kk', 'km', 'kn', 'ko', 'lij', 'lo', 'lt', 'ltg', 'lv', 'mai', 'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'ne-NP', 'nl', 'nn-NO', 'oc', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'si', 'sk', 'sl', 'sq', 'son', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tl', 'tr', 'trs', 'uk', 'ur', 'uz', 'vi', 'wo', 'xh', 'zh-CN', 'zh-TW']
 LATEST_FIREFOX_OLDER_VERSION = "3.6.28"


### PR DESCRIPTION
I'm not 100% sure this is needed (I don't think ship-it is used anymore?), but I saw that the Firefox version was bumped, so figured I'd do Thunderbird too.